### PR TITLE
[Android] update tf-lite 1.13

### DIFF
--- a/external/jni/Android-tensorflow-lite-1.13.1.mk
+++ b/external/jni/Android-tensorflow-lite-1.13.1.mk
@@ -41,6 +41,10 @@ CORE_CC_ALL_SRCS := \
     $(DOWNLOADS_DIR)/farmhash/src/farmhash.cc \
     $(DOWNLOADS_DIR)/fft2d/fftsg.c
 
+# NNAPI
+CORE_CC_ALL_SRCS += \
+    $(TF_LITE_DIR)/delegates/nnapi/nnapi_delegate.cc
+
 # Remove any duplicates.
 CORE_CC_ALL_SRCS := $(sort $(CORE_CC_ALL_SRCS))
 


### PR DESCRIPTION
nnapi-delegate file to build tf-lite 1.13.
Note that, officially tf-lite nnapi is available on 1.14, Android 8.1 (API level 27 or higher).

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
