### PR TITLE
[tflite] Revert git lfs for tflite lib and exclude x86s

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-external/tensorflow-lite-2.3.0.tar.xz filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
- Revert the previous commits. It cause exceed of github repo data capacity.
- Exclude x86 and x86_64 libs in tflite libs and unset git lfs

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>