### PR TITLE
README: add notice on licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# About this repository
+
+This repository provides pre-built binaries and headers for NNStreamer/NNTrainer Android packages.
+
+# License Notice
+
+Files in ```/external/``` have their own licenses and users should be aware of their licenses and use them accordingly.
+
+For example, PyTorch is basically Apache-2.0, but has GPL-3.0 files (headers) with GCC exceptions, which means that you need to build it with GCC in order to avoid GPL-3.0 conditions.


### PR DESCRIPTION
The files in /externals/ have different licenses.
Users should be aware of them.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>