### PR TITLE
[build] Add nnstreamer-edge root path in gradle.properties

### DIFF
--- a/android_api/gradle.properties
+++ b/android_api/gradle.properties
@@ -24,3 +24,7 @@ nnstreamerRoot=nnstreamer-path
 
 # ML API path (should be modified)
 mlApiRoot=ml-api-path
+
+# nnstreamer-edge path (should be modified)
+nnstreamerEdgeRoot=nnstreamer-edge-path
+


### PR DESCRIPTION
- Add nnstreamer-edge root path parameter in gradle.properties which is used by the android api build script.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>