### PR TITLE
Remove ndk.dir in Gradle local.properties

### DIFF
--- a/android_api/local.properties
+++ b/android_api/local.properties
@@ -4,5 +4,4 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-ndk.dir=ndk-path
 sdk.dir=sdk-path


### PR DESCRIPTION
This patch removes ndk.dir in Gradle local properties.
Using ndk.dir in local properties is deprecated and will be removed in a future release.
https://developer.android.com/studio/projects/install-ndk