### PR TITLE
External/TFLite: Add a file containing SHA-256 checksum

### DIFF
--- a/external/tensorflow-lite-2.8.1.tar.xz.sha256sum
+++ b/external/tensorflow-lite-2.8.1.tar.xz.sha256sum
@@ -1,0 +1,1 @@
+a88f7b98fb87e068a712286670c7e8268b6cf6000e4a03d48ce8bd52cc561acd  tensorflow-lite-2.8.1.tar.xz


### PR DESCRIPTION
This patch adds a file that contains SHA-256 checksum of the TensorFlow Lite v2.8.1's XZ compressed data file.

Signed-off-by: Wook Song <wook16.song@samsung.com>
