### PR TITLE
[llamacpp] Add llamacpp b4358 prebuilt lib and header

### DIFF
--- a/external/README.md
+++ b/external/README.md
@@ -2,7 +2,7 @@
 
 ## Encoder ( encoder-0.1.tar.gz )
 
-this tar file contains below files 
+this tar file contains below files
 
 1. ctre-unicode.hpp
    - compile-time-regular-expressions for unicode in C++
@@ -12,3 +12,8 @@ this tar file contains below files
    - JSON for Modern C++, this will parsing json file
    - original url : https://github.com/nlohmann/json
    - **MIT License**
+
+## llama.cpp ( llamacpp-b4358.tar.xz )
+
+- https://github.com/ggerganov/llama.cpp/releases/tag/b4358
+- Prebuilt with ndk-r25c for android-33


### PR DESCRIPTION
- Add llamacpp b4358 prebuilt lib and header
- https://github.com/ggerganov/llama.cpp/tree/master
- ndk version : 25.2.9519653
- android-platform : android-33